### PR TITLE
fix ch10/sem crashing when input is blank

### DIFF
--- a/ch10/sem/sem_env.go
+++ b/ch10/sem/sem_env.go
@@ -244,7 +244,8 @@ func (ev *SemEnv) Action(element string, input tensor.Tensor) {
 // String returns the string rep of the LED env state
 func (ev *SemEnv) String() string {
 	cpar := ev.CurPara()
-	if cpar == nil {
+
+	if cpar == nil || len(cpar) == 0 {
 		return ""
 	}
 	str := cpar[0]

--- a/ch10/sem/sem_env.go
+++ b/ch10/sem/sem_env.go
@@ -244,7 +244,6 @@ func (ev *SemEnv) Action(element string, input tensor.Tensor) {
 // String returns the string rep of the LED env state
 func (ev *SemEnv) String() string {
 	cpar := ev.CurPara()
-
 	if cpar == nil || len(cpar) == 0 {
 		return ""
 	}

--- a/ch10/sem/sem_env.go
+++ b/ch10/sem/sem_env.go
@@ -244,7 +244,7 @@ func (ev *SemEnv) Action(element string, input tensor.Tensor) {
 // String returns the string rep of the LED env state
 func (ev *SemEnv) String() string {
 	cpar := ev.CurPara()
-	if cpar == nil || len(cpar) == 0 {
+	if len(cpar) == 0 {
 		return ""
 	}
 	str := cpar[0]


### PR DESCRIPTION
When running ch10/sem, the simulation would crash in Test mode when one of the two input fields (Words1 and Words2) is blank or contains only whitespace, throwing the error:

```
panic: runtime error: index out of range [0] with length 0
```

This is because `cpar` is non-nil but contains no elements.

This is a simple one-line fix that checks if `cpar` is an empty list. I'm still not sure if this is the intended behavior for empty input (for example if I populate Words1 and make Words2 empty, I get a positive correlation for some reason, but when I make Words1 empty and populate Words2, I get a correlation of 0, which doesn't seem consistent), but at least the simulation doesn't crash in this scenario now.